### PR TITLE
Rolled PGE version number to 2.1.2 for R2 PGEs

### DIFF
--- a/examples/cslc_s1_sample_runconfig-v2.1.2.yaml
+++ b/examples/cslc_s1_sample_runconfig-v2.1.2.yaml
@@ -1,4 +1,4 @@
-# Sample RunConfig for use with the CSLC-S1 PGE v2.1.1
+# Sample RunConfig for use with the CSLC-S1 PGE v2.1.2
 # This RunConfig should require minimal changes in order to be used with the
 # OPERA PCM.
 

--- a/examples/rtc_s1_sample_runconfig-v2.1.2.yaml
+++ b/examples/rtc_s1_sample_runconfig-v2.1.2.yaml
@@ -1,4 +1,4 @@
-# Sample RunConfig for use with the RTC-S1 PGE v2.1.1
+# Sample RunConfig for use with the RTC-S1 PGE v2.1.2
 # This RunConfig should require minimal changes in order to be used with the
 # OPERA PCM.
 

--- a/src/opera/pge/cslc_s1/cslc_s1_pge.py
+++ b/src/opera/pge/cslc_s1/cslc_s1_pge.py
@@ -857,7 +857,7 @@ class CslcS1Executor(CslcS1PreProcessorMixin, CslcS1PostProcessorMixin, PgeExecu
     LEVEL = "L2"
     """Processing Level for CSLC-S1 Products"""
 
-    PGE_VERSION = "2.1.1"
+    PGE_VERSION = "2.1.2"
     """Version of the PGE (overrides default from base_pge)"""
 
     SAS_VERSION = "0.5.5"  # Final release https://github.com/opera-adt/COMPASS/releases/tag/v0.5.5

--- a/src/opera/pge/rtc_s1/rtc_s1_pge.py
+++ b/src/opera/pge/rtc_s1/rtc_s1_pge.py
@@ -949,7 +949,7 @@ class RtcS1Executor(RtcS1PreProcessorMixin, RtcS1PostProcessorMixin, PgeExecutor
     LEVEL = "L2"
     """Processing Level for RTC-S1 Products"""
 
-    PGE_VERSION = "2.1.1"
+    PGE_VERSION = "2.1.2"
     """Version of the PGE (overrides default from base_pge)"""
 
     SAS_VERSION = "1.0.2"  # Final release https://github.com/opera-adt/RTC/releases/tag/v1.0.2


### PR DESCRIPTION
### Description

The changes in this pull request update the version numbers in the sample run configurations and PGE Python files for CSLC-S1 and RTC-S1 PGEs from v2.1.1 to v2.1.2.

- Renamed `examples/cslc_s1_sample_runconfig-v2.1.2.yaml`
- Renamed `examples/rtc_s1_sample_runconfig-v2.1.2.yaml`
- Updated PGE version in `src/opera/pge/cslc_s1/cslc_s1_pge.py` from 2.1.1 to 2.1.2
- Updated PGE version in `src/opera/pge/rtc_s1/rtc_s1_pge.py` from 2.1.1 to 2.1.2


<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update the PGE version number from 2.1.1 to 2.1.2 in the CSLC-S1 and RTC-S1 sample run configuration files and source code.

### Why are these changes being made?

These changes ensure that the documentation and source code reflect the latest version of the PGE, which may include bug fixes, improvements, or new features. This update maintains consistency across the codebase and associated configuration files, ensuring users are aware of the current version being used.

<!-- Korbit AI PR Description End -->